### PR TITLE
Simplify ConnectionDetails::fromArray

### DIFF
--- a/app/container_configuration.php
+++ b/app/container_configuration.php
@@ -84,7 +84,7 @@ return [
         ContainerInterface $container
     ) {
         $configuration = $container->get(Configuration::class);
-        $connectionDetails = ConnectionDetails::fromArray($configuration);
+        $connectionDetails = ConnectionDetails::fromArray($configuration['connection']);
         $logger->info('Creating connection', [
             'server' => $connectionDetails->getAddress(),
             'port' => $connectionDetails->getPort()

--- a/src/Connection/ConnectionDetails.php
+++ b/src/Connection/ConnectionDetails.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace WildPHP\Core\Connection;
 
 use InvalidArgumentException;
+use WildPHP\Core\Helpers\Validation;
 
 class ConnectionDetails
 {
@@ -180,29 +181,20 @@ class ConnectionDetails
      */
     public static function fromArray(array $configuration): ConnectionDetails
     {
-        if (!array_key_exists('connection', $configuration)) {
-            throw new InvalidArgumentException('Invalid configuration given to ConnectionDetails::fromConfiguration');
-        }
-
-        $connectionInfo = $configuration['connection'];
-        $mandatoryKeys = ['username', 'server', 'port', 'realname', 'nickname'];
-
-        foreach ($mandatoryKeys as $key) {
-            if (!array_key_exists($key, $connectionInfo)) {
-                throw new InvalidArgumentException('Missing keys in configuration given to ConnectionDetails::fromConfiguration');
-            }
+        if (!Validation::arrayHasKeys($configuration, ['username', 'server', 'port', 'realname', 'nickname'])) {
+            throw new InvalidArgumentException('Missing keys in configuration given to ConnectionDetails::fromArray');
         }
 
         return new ConnectionDetails(
-            $connectionInfo['username'],
+            $configuration['username'],
             gethostname(),
-            $connectionInfo['server'],
-            $connectionInfo['port'],
-            $connectionInfo['realname'],
-            $connectionInfo['password'] ?? '',
-            $connectionInfo['nickname'][0],
-            $connectionInfo['secure'] ?? false,
-            $connectionInfo['options'] ?? []
+            $configuration['server'],
+            $configuration['port'],
+            $configuration['realname'],
+            $configuration['password'] ?? '',
+            $configuration['nickname'][0],
+            $configuration['secure'] ?? false,
+            $configuration['options'] ?? []
         );
     }
 }

--- a/src/Helpers/Validation.php
+++ b/src/Helpers/Validation.php
@@ -92,4 +92,22 @@ class Validation
     {
         return $value ?? $default;
     }
+
+    /**
+     * Determines if the given array has the specified keys.
+     *
+     * @param array $array the array to check
+     * @param array $mandatoryKeys the keys that the array must contain
+     * @return bool
+     */
+    public static function arrayHasKeys(array $array, array $mandatoryKeys): bool
+    {
+        foreach ($mandatoryKeys as $key) {
+            if (!array_key_exists($key, $array)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/tests/Connection/ConnectionDetailsTest.php
+++ b/tests/Connection/ConnectionDetailsTest.php
@@ -100,17 +100,15 @@ class ConnectionDetailsTest extends TestCase
     public function testFromArray()
     {
         $details = [
-            'connection' => [
-                'server' => 'irc.freenode.net',
-                'port' => 6697,
-                'secure' => true,
-                'nickname' => [
-                    'MyBot'
-                ],
-                'username' => 'MyBot',
-                'realname' => 'A WildPHP Bot',
-                'password' => 'tester'
+            'server' => 'irc.freenode.net',
+            'port' => 6697,
+            'secure' => true,
+            'nickname' => [
+                'MyBot'
             ],
+            'username' => 'MyBot',
+            'realname' => 'A WildPHP Bot',
+            'password' => 'tester'
         ];
 
         $connectionDetails = ConnectionDetails::fromArray($details);
@@ -124,11 +122,10 @@ class ConnectionDetailsTest extends TestCase
         self::assertEquals('tester', $connectionDetails->getPassword());
     }
 
-    public function testFromArrayMissingRootKey()
+    public function testFromArrayMissingMandatoryKeys()
     {
         $details = [
-            'server' => 'irc.freenode.net',
-            'port' => 6697,
+            // server and port are missing
             'secure' => true,
             'nickname' => [
                 'MyBot'
@@ -136,25 +133,6 @@ class ConnectionDetailsTest extends TestCase
             'username' => 'MyBot',
             'realname' => 'A WildPHP Bot',
             'password' => 'tester'
-        ];
-
-        $this->expectException(\InvalidArgumentException::class);
-        ConnectionDetails::fromArray($details);
-    }
-
-    public function testFromArrayMissingMandatoryKeys()
-    {
-        $details = [
-            'connection' => [
-                // server and port are missing
-                'secure' => true,
-                'nickname' => [
-                    'MyBot'
-                ],
-                'username' => 'MyBot',
-                'realname' => 'A WildPHP Bot',
-                'password' => 'tester'
-            ],
         ];
 
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Helpers/ValidationTest.php
+++ b/tests/Helpers/ValidationTest.php
@@ -54,4 +54,22 @@ class ValidationTest extends TestCase
         self::assertNull(Validation::defaultTypeValue('null'));
         self::assertNull(Validation::defaultTypeValue('AAAAAAAAAA'));
     }
+
+    public function testArrayHasKeys()
+    {
+        $array = [
+            'test' => 'ing',
+            0 => 1
+        ];
+
+        self::assertTrue(Validation::arrayHasKeys($array, ['test']));
+        self::assertTrue(Validation::arrayHasKeys($array, [0]));
+
+        // order should not matter
+        self::assertTrue(Validation::arrayHasKeys($array, ['test', 0]));
+        self::assertTrue(Validation::arrayHasKeys($array, [0, 'test']));
+
+        self::assertFalse(Validation::arrayHasKeys($array, ['testing']));
+        self::assertFalse(Validation::arrayHasKeys($array, ['test', 0, 'testing']));
+    }
 }


### PR DESCRIPTION
Remove the seemingly arbitrary check for the connection root key and instead just pass the connection array directly to the method.

This also prevents us from passing the entire configuration tree into the method which in turn should fix #160 .