### PR TITLE
Create a new user object in WhosPcRpl if it does not exist yet

### DIFF
--- a/src/Observers/WhosPcRplObserver.php
+++ b/src/Observers/WhosPcRplObserver.php
@@ -56,8 +56,7 @@ class WhosPcRplObserver
         /** @var WhosPcRpl $ircMessage */
         $ircMessage = $ircMessageEvent->getIncomingMessage();
 
-        /** @var IrcUser $user */
-        $user = $this->userStorage->getOneByNickname($ircMessage->getNickname());
+        $user = $this->userStorage->getOrCreateOneByNickname($ircMessage->getNickname());
         $user->nickname = $ircMessage->getNickname();
         $user->username = $ircMessage->getUsername();
         $user->hostname = $ircMessage->getHostname();


### PR DESCRIPTION
This should fix #163 with hopefully no side effects. All user information should be in the WhosPcRpl message and thus creating users at this stage should be safe.