### PR TITLE
Change (user|channel)Id property to just 'id'

### DIFF
--- a/.idea/irc-bot.iml
+++ b/.idea/irc-bot.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="WildPHP\Core\" />
       <sourceFolder url="file://$MODULE_DIR$/modules" isTestSource="false" packagePrefix="WildPHP\Modules\" />
-      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="false" packagePrefix="WildPHP\Tests\" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/logs" />
       <excludeFolder url="file://$MODULE_DIR$/vendor" />

--- a/src/Connection/Capabilities/AccountNotifyHandler.php
+++ b/src/Connection/Capabilities/AccountNotifyHandler.php
@@ -69,7 +69,7 @@ class AccountNotifyHandler extends RequestOnlyHandler
 
         $this->logger->debug('Updated IRC account', [
             'reason' => 'account_notify',
-            'userID' => $user->userId,
+            'userID' => $user->id,
             'nickname' => $user->nickname,
             'new_ircAccount' => $user->ircAccount
         ]);

--- a/src/Entities/IrcChannel.php
+++ b/src/Entities/IrcChannel.php
@@ -14,7 +14,7 @@ namespace WildPHP\Core\Entities;
  * Class IrcChannel
  * @package WildPHP\Core\Entities
  *
- * @property int $channelId
+ * @property int $id
  * @property string $name
  * @property string $topic
  * @property EntityModes $modes
@@ -23,7 +23,7 @@ namespace WildPHP\Core\Entities;
 class IrcChannel extends Model
 {
     protected $settable = [
-        'channelId' => 'integer',
+        'id' => 'integer',
         'name' => 'string',
         'topic' => 'string',
         'modes' => EntityModes::class,

--- a/src/Entities/IrcUser.php
+++ b/src/Entities/IrcUser.php
@@ -14,7 +14,7 @@ namespace WildPHP\Core\Entities;
  * Class IrcUser
  * @package WildPHP\Core\Entities
  *
- * @property int $userId
+ * @property int $id
  * @property string $nickname
  * @property string $hostname
  * @property string $username
@@ -25,7 +25,7 @@ namespace WildPHP\Core\Entities;
 class IrcUser extends Model
 {
     protected $settable = [
-        'userId' => 'integer',
+        'id' => 'integer',
         'nickname' => 'string',
         'hostname' => 'string',
         'username' => 'string',

--- a/src/Observers/InitialBotUserCreator.php
+++ b/src/Observers/InitialBotUserCreator.php
@@ -54,7 +54,7 @@ class InitialBotUserCreator
         $nickname = $message->getNickname();
         $user = $this->userStorage->getOrCreateOneByNickname($nickname);
         $this->logger->debug('Created initial user; my job is done', [
-            'id' => $user->userId,
+            'id' => $user->id,
             'nickname' => $nickname
         ]);
     }

--- a/src/Observers/JoinObserver.php
+++ b/src/Observers/JoinObserver.php
@@ -78,8 +78,8 @@ class JoinObserver
             $channel = $this->channelStorage->getOrCreateOneByName($channelName);
 
             $relation = $this->relationStorage->getOrCreateOne(
-                $user->userId,
-                $channel->channelId
+                $user->id,
+                $channel->id
             );
 
             $this->logger->debug('Creating user-channel relationship', [
@@ -110,7 +110,7 @@ class JoinObserver
 
         $this->logger->debug('Updated user', [
             'reason' => 'join',
-            'id' => $user->userId,
+            'id' => $user->id,
             'nickname' => $joinMessage->getNickname(),
             'username' => $prefix->getUsername(),
             'hostname' => $prefix->getHostname(),
@@ -121,7 +121,7 @@ class JoinObserver
 
         $this->logger->debug('Set online flag for user', [
             'reason' => 'join',
-            'id' => $user->userId,
+            'id' => $user->id,
             'nickname' => $user->nickname,
             'newValue' => $user->online
         ]);

--- a/src/Observers/KickObserver.php
+++ b/src/Observers/KickObserver.php
@@ -80,7 +80,7 @@ class KickObserver
         $channel = $this->channelStorage->getOneByName($kickMessage->getChannel());
 
         $this->relationStorage->delete(
-            $this->relationStorage->getOne($user->userId, $channel->channelId)
+            $this->relationStorage->getOne($user->id, $channel->id)
         );
 
         $this->logger->debug('Removed user-channel relationship', [

--- a/src/Observers/ModeObserver.php
+++ b/src/Observers/ModeObserver.php
@@ -99,7 +99,7 @@ class ModeObserver
             }
 
             $this->logger->debug('Changed modes for user', [
-                'userID' => $user->userId,
+                'userID' => $user->id,
                 'nickname' => $user->nickname,
                 'modes' => $flags,
                 'added' => $add,
@@ -122,7 +122,7 @@ class ModeObserver
                 $userInChannel = $this->userStorage->getOneByNickname($args[$parameterIndex]);
 
                 $entityModes = $userInChannel !== null
-                    ? $channel->getModesForUserId($userInChannel->userId)
+                    ? $channel->getModesForUserId($userInChannel->id)
                     : $channel->modes;
 
                 if ($add) {
@@ -132,9 +132,9 @@ class ModeObserver
                 }
 
                 $this->logger->debug('Changed mode for user inside channel', [
-                    'channelID' => $channel->channelId,
+                    'channelID' => $channel->id,
                     'name' => $channel->name,
-                    'userID' => $userInChannel->userId,
+                    'userID' => $userInChannel->id,
                     'nickname' => $userInChannel->nickname,
                     'flag' => $flag,
                     'added' => $add
@@ -151,7 +151,7 @@ class ModeObserver
             }
 
             $this->logger->debug('Changed mode for channel', [
-                'channelID' => $channel->channelId,
+                'channelID' => $channel->id,
                 'name' => $channel->name,
                 'modes' => $flag,
                 'added' => $add

--- a/src/Observers/NamReplyObserver.php
+++ b/src/Observers/NamReplyObserver.php
@@ -89,7 +89,7 @@ class NamReplyObserver
 
                 $this->logger->debug('Set online flag for user', [
                     'reason' => 'RPL_NAMREPLY',
-                    'id' => $user->userId,
+                    'id' => $user->id,
                     'nickname' => $user->nickname,
                     'newValue' => $user->online
                 ]);
@@ -98,11 +98,11 @@ class NamReplyObserver
             $modes = $ircMessage->getModes()[$nickname];
             foreach ($modes as $mode) {
                 $this->logger->debug('Added user to mode', [
-                    'userID' => $user->userId,
+                    'userID' => $user->id,
                     'nickname' => $user->nickname,
                     'mode' => $mode
                 ]);
-                $channel->getModesForUserId($user->userId)->addMode($mode);
+                $channel->getModesForUserId($user->id)->addMode($mode);
             }
 
             // userhost-in-names support
@@ -114,8 +114,8 @@ class NamReplyObserver
             }
 
             $relation = $this->relationStorage->getOrCreateOne(
-                $user->userId,
-                $channel->channelId
+                $user->id,
+                $channel->id
             );
 
             $this->logger->debug('Creating user-channel relationship', [

--- a/src/Observers/PartObserver.php
+++ b/src/Observers/PartObserver.php
@@ -81,7 +81,7 @@ class PartObserver
             $channel = $this->channelStorage->getOneByName($channelName);
 
             $this->relationStorage->delete(
-                $this->relationStorage->getOne($user->userId, $channel->channelId)
+                $this->relationStorage->getOne($user->id, $channel->id)
             );
 
             $this->logger->debug('Removed user-channel relationship', [
@@ -91,13 +91,13 @@ class PartObserver
             ]);
         }
 
-        if (empty($this->relationStorage->getByUserId($user->userId))) {
+        if (empty($this->relationStorage->getByUserId($user->id))) {
             $user->online = false;
             $this->userStorage->store($user);
 
             $this->logger->debug('This user has left all mutual channels; assuming offline. Updated online flag', [
                 'reason' => 'part',
-                'id' => $user->userId,
+                'id' => $user->id,
                 'nickname' => $user->nickname,
                 'newValue' => $user->online
             ]);

--- a/src/Observers/QuitObserver.php
+++ b/src/Observers/QuitObserver.php
@@ -67,7 +67,7 @@ class QuitObserver
         /** @var IrcUser $user */
         $user = $this->userStorage->getOneByNickname($quitMessage->getNickname());
 
-        foreach ($this->relationStorage->getByUserId($user->userId) as $relation) {
+        foreach ($this->relationStorage->getByUserId($user->id) as $relation) {
             $this->relationStorage->delete($relation);
         }
 
@@ -81,7 +81,7 @@ class QuitObserver
 
         $this->logger->debug('Set online flag for user', [
             'reason' => 'quit',
-            'id' => $user->userId,
+            'id' => $user->id,
             'nickname' => $user->nickname,
             'newValue' => $user->online
         ]);

--- a/src/Storage/IrcChannelStorage.php
+++ b/src/Storage/IrcChannelStorage.php
@@ -35,7 +35,7 @@ class IrcChannelStorage implements IrcChannelStorageInterface
      */
     public function store(IrcChannel $channel): void
     {
-        if (empty($channel->channelId) || $channel->channelId < 1) {
+        if (empty($channel->id) || $channel->id < 1) {
             $this->giveId($channel);
         }
 
@@ -48,11 +48,11 @@ class IrcChannelStorage implements IrcChannelStorageInterface
      */
     public function delete(IrcChannel $channel): void
     {
-        if (empty($channel->channelId) || !$this->has($channel->channelId)) {
+        if (empty($channel->id) || !$this->has($channel->id)) {
             throw new StorageException('Cannot delete channel without ID or channel which is not stored');
         }
 
-        $this->storageProvider->delete($this->database, ['id' => $channel->channelId]);
+        $this->storageProvider->delete($this->database, ['id' => $channel->id]);
     }
 
     /**
@@ -144,11 +144,11 @@ class IrcChannelStorage implements IrcChannelStorageInterface
      */
     protected function giveId(IrcChannel $channel): void
     {
-        if (!empty($channel->channelId)) {
+        if (!empty($channel->id)) {
             return;
         }
 
         $channels = $this->getAll();
-        $channel->channelId = count($channels) > 0 ? (int) max(array_keys($channels)) + 1 : 1;
+        $channel->id = count($channels) > 0 ? (int) max(array_keys($channels)) + 1 : 1;
     }
 }

--- a/src/Storage/IrcChannelStorageAdapter.php
+++ b/src/Storage/IrcChannelStorageAdapter.php
@@ -20,7 +20,7 @@ class IrcChannelStorageAdapter
      */
     public static function convertToStoredEntity(IrcChannel $channel): StoredEntity
     {
-        return new StoredEntity($channel->toArray(), $channel->channelId);
+        return new StoredEntity($channel->toArray(), $channel->id);
     }
 
     /**

--- a/src/Storage/IrcUserStorage.php
+++ b/src/Storage/IrcUserStorage.php
@@ -36,7 +36,7 @@ class IrcUserStorage implements IrcUserStorageInterface
      */
     public function store(IrcUser $user): void
     {
-        if (empty($user->userId) || $user->userId < 1) {
+        if (empty($user->id) || $user->id < 1) {
             $this->giveId($user);
         }
 
@@ -49,11 +49,11 @@ class IrcUserStorage implements IrcUserStorageInterface
      */
     public function delete(IrcUser $user): void
     {
-        if (empty($user->userId) || !$this->has($user->userId)) {
+        if (empty($user->id) || !$this->has($user->id)) {
             throw new StorageException('Cannot delete user without ID or channel which is not stored');
         }
 
-        $this->storageProvider->delete($this->database, ['id' => $user->userId]);
+        $this->storageProvider->delete($this->database, ['id' => $user->id]);
     }
 
     /**
@@ -190,11 +190,11 @@ class IrcUserStorage implements IrcUserStorageInterface
      */
     protected function giveId(IrcUser $user): void
     {
-        if (!empty($user->userId)) {
+        if (!empty($user->id)) {
             return;
         }
 
         $users = $this->getAll();
-        $user->userId = count($users) > 0 ? (int)max(array_keys($users)) + 1 : 1;
+        $user->id = count($users) > 0 ? (int)max(array_keys($users)) + 1 : 1;
     }
 }

--- a/src/Storage/IrcUserStorageAdapter.php
+++ b/src/Storage/IrcUserStorageAdapter.php
@@ -20,7 +20,7 @@ class IrcUserStorageAdapter
      */
     public static function convertToStoredEntity(IrcUser $user): StoredEntity
     {
-        return new StoredEntity($user->toArray(), $user->userId);
+        return new StoredEntity($user->toArray(), $user->id);
     }
 
     /**

--- a/src/Storage/StorageCleaner.php
+++ b/src/Storage/StorageCleaner.php
@@ -34,7 +34,7 @@ class StorageCleaner
         $nicknames = [];
         foreach ($userStorage->getAll() as $user) {
             $logger->debug('Processing user...', [
-                'id' => $user->userId,
+                'id' => $user->id,
                 'nickname' => $user->nickname
             ]);
 
@@ -59,7 +59,7 @@ class StorageCleaner
         $logger->debug('Removing set modes & topics for channels...');
         foreach ($channelStorage->getAll() as $channel) {
             $logger->debug('Processing channel...', [
-                'id' => $channel->channelId,
+                'id' => $channel->id,
                 'name' => $channel->name
             ]);
             $channel->topic = '';


### PR DESCRIPTION
This allows the storage subsystem to automatically fill in the entity ID when retrieving entities. This also means entities are now given a proper ID.

This fixes #163.