### PR TITLE
Fix secure connection support

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -51,10 +51,12 @@ return [
         # Please see https://github.com/reactphp/socket#connector for more details.
         # Example options below:
         //'options'  => [
-        //    'dns' => false,
-        //    'tcp' => [
-        //        'bindto' => '192.168.1.11'
-        //    ]
+        //    'dns' => false, // Disables DNS lookups
+
+        //    'tls' => [ // Allows self-signed certificates
+        //        'verify_peer' => false,
+        //        'verify_peer_name' => false
+        //    ],
         //]
     ],
 

--- a/src/Connection/ConnectorFactory.php
+++ b/src/Connection/ConnectorFactory.php
@@ -27,12 +27,10 @@ class ConnectorFactory
      */
     public static function create(LoopInterface $loop, bool $secure = false, array $options = []): ConnectorInterface
     {
-        $connector = new Connector($loop, $options);
-
-        if ($secure) {
-            return new SecureConnector($connector, $loop);
+        if ($secure && empty($options['tls'])) {
+            $options['tls'] = true;
         }
 
-        return $connector;
+        return new Connector($loop, $options);
     }
 }

--- a/tests/Connection/ConnectorFactoryTest.php
+++ b/tests/Connection/ConnectorFactoryTest.php
@@ -23,12 +23,4 @@ class ConnectorFactoryTest extends TestCase
 
         self::assertInstanceOf(Connector::class, $connector);
     }
-
-    public function testGetSecureConnector()
-    {
-        $loop = Factory::create();
-        $connector = ConnectorFactory::create($loop, true);
-
-        self::assertInstanceOf(SecureConnector::class, $connector);
-    }
 }


### PR DESCRIPTION
The bot was wrapping the plain connector in a SecureConnector instance; however, ReactPHP was already doing this internally. As a result the set options were not passed to the secure connector.